### PR TITLE
ERC7683 Tribunal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/the-compact"]
 	path = lib/the-compact
 	url = https://github.com/uniswap/the-compact
+[submodule "lib/solady"]
+	path = lib/solady
+	url = https://github.com/vectorized/solady

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,3 +9,6 @@ bytecode_hash = "none"
 
 [fmt]
 line_length = 100
+
+[profile.remappings]
+solady = "lib/solady/src"

--- a/src/ERC7683Tribunal.sol
+++ b/src/ERC7683Tribunal.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IDestinationSettler} from "./Interfaces/IDestinationSettler.sol";
+import {Tribunal} from "./Tribunal.sol";
+
+/// @title ERC7683Tribunal
+/// @notice A contract that enables the tribunal compatibility with the ERC7683 destination settler interface
+contract ERC7683Tribunal is Tribunal, IDestinationSettler {
+    // ======== Constructor ========
+    constructor() {}
+
+    // ======== External Functions ========
+    function fill(bytes32, bytes calldata originData, bytes calldata fillerData) external {
+        (Claim memory claim, Mandate memory mandate) = abi.decode(originData, (Claim, Mandate));
+        address claimant = abi.decode(fillerData, (address));
+
+        _fill(claim, mandate, claimant);
+    }
+
+    function quote(bytes32, bytes calldata originData, bytes calldata fillerData)
+        external
+        view
+        returns (uint256 dispensation)
+    {
+        (Claim memory claim, Mandate memory mandate) = abi.decode(originData, (Claim, Mandate));
+        address claimant = abi.decode(fillerData, (address));
+
+        return _quote(claim, mandate, claimant);
+    }
+}

--- a/src/ERC7683Tribunal.sol
+++ b/src/ERC7683Tribunal.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {LibBytes} from "solady/utils/LibBytes.sol";
+
 import {IDestinationSettler} from "./Interfaces/IDestinationSettler.sol";
 import {Tribunal} from "./Tribunal.sol";
 
@@ -12,10 +14,16 @@ contract ERC7683Tribunal is Tribunal, IDestinationSettler {
 
     // ======== External Functions ========
     function fill(bytes32, bytes calldata originData, bytes calldata fillerData) external {
-        (Claim memory claim, Mandate memory mandate) = abi.decode(originData, (Claim, Mandate));
-        address claimant = abi.decode(fillerData, (address));
+        (
+            uint256 chainId,
+            Compact calldata compact,
+            bytes calldata sponsorSignature,
+            bytes calldata allocatorSignature,
+            Mandate calldata mandate,
+            address claimant
+        ) = _parseCalldata(originData, fillerData);
 
-        _fill(claim, mandate, claimant);
+        _fill(chainId, compact, sponsorSignature, allocatorSignature, mandate, claimant);
     }
 
     function quote(bytes32, bytes calldata originData, bytes calldata fillerData)
@@ -23,9 +31,69 @@ contract ERC7683Tribunal is Tribunal, IDestinationSettler {
         view
         returns (uint256 dispensation)
     {
-        (Claim memory claim, Mandate memory mandate) = abi.decode(originData, (Claim, Mandate));
-        address claimant = abi.decode(fillerData, (address));
+        (
+            uint256 chainId,
+            Compact calldata compact,
+            bytes calldata sponsorSignature,
+            bytes calldata allocatorSignature,
+            Mandate calldata mandate,
+            address claimant
+        ) = _parseCalldata(originData, fillerData);
 
-        return _quote(claim, mandate, claimant);
+        return _quote(chainId, compact, sponsorSignature, allocatorSignature, mandate, claimant);
+    }
+
+    /// @dev Parses the calldata to extract the necessary parameters without copying to memory
+    /// @param originData The encoded Claim and Mandate data
+    /// @param fillerData The encoded claimant address
+    /// @return chainId The chain ID from the Claim
+    /// @return compact The Compact struct from the Claim
+    /// @return sponsorSignature The sponsor signature from the Claim
+    /// @return allocatorSignature The allocator signature from the Claim
+    /// @return mandate The Mandate struct
+    /// @return claimant The claimant address
+    function _parseCalldata(bytes calldata originData, bytes calldata fillerData)
+        internal
+        pure
+        returns (
+            uint256 chainId,
+            Compact calldata compact,
+            bytes calldata sponsorSignature,
+            bytes calldata allocatorSignature,
+            Mandate calldata mandate,
+            address claimant
+        )
+    {
+        // Need at minimum:
+        // 1 word for offset to claim (dynamic struct)
+        // 7 words for mandate (fixed struct)
+        // 7 words for fixed claim fields
+        // 2 words for signature offsets
+        // 2 words for signature lengths (assuming empty)
+        // also ensure no funny business with the claim pointer (should be 0x100)
+        // filler data should also have at least one word for claimant with no dirty bits
+        assembly ("memory-safe") {
+            if or(
+                or(lt(originData.length, 0x260), xor(calldataload(originData.offset), 0x100)),
+                or(lt(fillerData.length, 0x20), shr(calldataload(fillerData.offset), 0xa0))
+            ) { revert(0, 0) }
+        }
+
+        // Get the claim encoded as a bytes array with bounds checks
+        bytes calldata encodedClaim = LibBytes.dynamicStructInCalldata(originData, 0x00);
+
+        // Extract static variables and structs directly
+        // Note: this doesn't sanitize struct elements; that should happen downstream
+        assembly ("memory-safe") {
+            chainId := calldataload(encodedClaim.offset)
+            compact := add(encodedClaim.offset, 0x20)
+            mandate := add(originData.offset, 0x20)
+            claimant := calldataload(fillerData.offset)
+        }
+
+        // Sponsor & allocator signature offsets at words 8 + 9 in encoded claim
+        // since first word is chainId and next six are the compact static struct
+        sponsorSignature = LibBytes.bytesInCalldata(encodedClaim, 0xe0);
+        allocatorSignature = LibBytes.bytesInCalldata(encodedClaim, 0x100);
     }
 }

--- a/src/Interfaces/IDestinationSettler.sol
+++ b/src/Interfaces/IDestinationSettler.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IDestinationSettler
+/// @notice Standard interface for settlement contracts on the destination chain
+interface IDestinationSettler {
+    /// @notice Fills a single leg of a particular order on the destination chain
+    /// @param orderId Unique order identifier for this order
+    /// @param originData Data emitted on the origin to parameterize the fill
+    /// @param fillerData Data provided by the filler to inform the fill or express their preferences
+    function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) external;
+}

--- a/src/Tribunal.sol
+++ b/src/Tribunal.sol
@@ -155,7 +155,7 @@ contract Tribunal {
      * @param mandate The mandate containing all hash parameters
      * @return The derived mandate hash
      */
-    function deriveMandateHash(Mandate calldata mandate) public view returns (bytes32) {
+    function deriveMandateHash(Mandate memory mandate) public view returns (bytes32) {
         return keccak256(
             abi.encode(
                 MANDATE_TYPEHASH,
@@ -178,7 +178,7 @@ contract Tribunal {
      * @param mandateHash The derived mandate hash
      * @return The claim hash
      */
-    function deriveClaimHash(Claim calldata claim, bytes32 mandateHash)
+    function deriveClaimHash(Claim memory claim, bytes32 mandateHash)
         public
         pure
         returns (bytes32)
@@ -237,7 +237,7 @@ contract Tribunal {
         return (fillAmount, claimAmount);
     }
 
-    function _fill(Claim calldata claim, Mandate calldata mandate, address claimant)
+    function _fill(Claim memory claim, Mandate memory mandate, address claimant)
         internal
         returns (bytes32 mandateHash, uint256 fillAmount, uint256 claimAmount)
     {
@@ -285,7 +285,7 @@ contract Tribunal {
         }
     }
 
-    function _quote(Claim calldata claim, Mandate calldata mandate, address claimant)
+    function _quote(Claim memory claim, Mandate memory mandate, address claimant)
         internal
         view
         returns (uint256 dispensation)
@@ -343,7 +343,7 @@ contract Tribunal {
      * @param claimAmount The amount to claim
      */
     function _processDirective(
-        Claim calldata claim,
+        Claim memory claim,
         bytes32 mandateHash,
         address claimant,
         uint256 claimAmount
@@ -361,7 +361,7 @@ contract Tribunal {
      * @return dispensation The quoted dispensation amount
      */
     function _quoteDirective(
-        Claim calldata claim,
+        Claim memory claim,
         bytes32 mandateHash,
         address claimant,
         uint256 claimAmount

--- a/test/ERC7683Tribunal.t.sol
+++ b/test/ERC7683Tribunal.t.sol
@@ -73,19 +73,21 @@ abstract contract MockSetup is Test {
         minimumFillAmount = 1 ether;
         claimAmount = 10 ether;
 
+        address arbiter = makeAddr("Arbiter");
+
         ERC7683Tribunal.Mandate memory mandate = _getMandate();
         claim = Tribunal.Claim({
             chainId: block.chainid,
             compact: Tribunal.Compact({
-                arbiter: makeAddr("Arbiter"),
+                arbiter: arbiter,
                 sponsor: sponsor,
                 nonce: uint256(bytes32(abi.encodePacked(sponsor, uint96(0)))),
                 expires: 1703116800,
                 id: 1,
                 amount: claimAmount
             }),
-            sponsorSignature: new bytes(0),
-            allocatorSignature: new bytes(0)
+            sponsorSignature: hex"abcd",
+            allocatorSignature: hex"1234"
         });
         Output memory outputMaxSpent = Output({
             token: bytes32(uint256(uint160(address(token)))),
@@ -161,7 +163,7 @@ contract ERC7683Tribunal_Fill is MockSetup {
 
         Tribunal.Mandate memory mandate = _getMandate();
         bytes32 mandateHash = tribunal.deriveMandateHash(mandate);
-        bytes32 claimHash = tribunal.deriveClaimHash(claim, mandateHash);
+        bytes32 claimHash = tribunal.deriveClaimHash(claim.compact, mandateHash);
 
         vm.expectEmit(true, true, false, true, address(tribunal));
         emit Tribunal.Fill(sponsor, filler, claimHash, minimumFillAmount, claimAmount);

--- a/test/ERC7683Tribunal.t.sol
+++ b/test/ERC7683Tribunal.t.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC7683Tribunal} from "../src/ERC7683Tribunal.sol";
+import {Tribunal} from "../src/Tribunal.sol";
+import {FixedPointMathLib} from "the-compact/lib/solady/src/utils/FixedPointMathLib.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+
+abstract contract MockSetup is Test {
+    struct ResolvedCrossChainOrder {
+        /// @dev The address of the user who is initiating the transfer
+        address user;
+        /// @dev The chainId of the origin chain
+        uint256 originChainId;
+        /// @dev The timestamp by which the order must be opened
+        uint32 openDeadline;
+        /// @dev The timestamp by which the order must be filled on the destination chain(s)
+        uint32 fillDeadline;
+        /// @dev The unique identifier for this order within this settlement system
+        bytes32 orderId;
+        /// @dev The max outputs that the filler will send. It's possible the actual amount depends on the state of the destination
+        ///      chain (destination dutch auction, for instance), so these outputs should be considered a cap on filler liabilities.
+        Output[] maxSpent;
+        /// @dev The minimum outputs that must be given to the filler as part of order settlement. Similar to maxSpent, it's possible
+        ///      that special order types may not be able to guarantee the exact amount at open time, so this should be considered
+        ///      a floor on filler receipts.
+        Output[] minReceived;
+        /// @dev Each instruction in this array is parameterizes a single leg of the fill. This provides the filler with the information
+        ///      necessary to perform the fill on the destination(s).
+        FillInstruction[] fillInstructions;
+    }
+
+    /// @notice Tokens that must be received for a valid order fulfillment
+    struct Output {
+        /// @dev The address of the ERC20 token on the destination chain
+        /// @dev address(0) used as a sentinel for the native token
+        bytes32 token;
+        /// @dev The amount of the token to be sent
+        uint256 amount;
+        /// @dev The address to receive the output tokens
+        bytes32 recipient;
+        /// @dev The destination chain for this output
+        uint256 chainId;
+    }
+
+    /// @title FillInstruction type
+    /// @notice Instructions to parameterize each leg of the fill
+    /// @dev Provides all the origin-generated information required to produce a valid fill leg
+    struct FillInstruction {
+        /// @dev The contract address that the order is meant to be settled by
+        uint256 destinationChainId;
+        /// @dev The contract address that the order is meant to be filled on
+        bytes32 destinationSettler;
+        /// @dev The data generated on the origin chain needed by the destinationSettler to process the fill
+        bytes originData;
+    }
+
+    ERC7683Tribunal public tribunal;
+    MockERC20 public token;
+    address sponsor;
+    address filler;
+    uint256 minimumFillAmount;
+    uint256 claimAmount;
+    ResolvedCrossChainOrder public order;
+    Tribunal.Claim public claim;
+
+    function setUp() public {
+        tribunal = new ERC7683Tribunal();
+        token = new MockERC20();
+        sponsor = makeAddr("Sponsor");
+        filler = makeAddr("Filler");
+        minimumFillAmount = 1 ether;
+        claimAmount = 10 ether;
+
+        ERC7683Tribunal.Mandate memory mandate = _getMandate();
+        claim = Tribunal.Claim({
+            chainId: block.chainid,
+            compact: Tribunal.Compact({
+                arbiter: makeAddr("Arbiter"),
+                sponsor: sponsor,
+                nonce: uint256(bytes32(abi.encodePacked(sponsor, uint96(0)))),
+                expires: 1703116800,
+                id: 1,
+                amount: claimAmount
+            }),
+            sponsorSignature: new bytes(0),
+            allocatorSignature: new bytes(0)
+        });
+        Output memory outputMaxSpent = Output({
+            token: bytes32(uint256(uint160(address(token)))),
+            amount: type(uint256).max,
+            recipient: bytes32(uint256(uint160(sponsor))),
+            chainId: block.chainid
+        });
+        Output memory outputMinReceived = Output({
+            token: bytes32(uint256(uint160(address(token)))),
+            amount: claimAmount,
+            recipient: bytes32(uint256(uint160(0))),
+            chainId: 1
+        });
+        FillInstruction memory fillInstruction = FillInstruction({
+            destinationChainId: 1,
+            destinationSettler: bytes32(uint256(uint160(address(tribunal)))),
+            originData: abi.encode(claim, mandate)
+        });
+        Output[] memory maxSpent = new Output[](1);
+        maxSpent[0] = outputMaxSpent;
+        Output[] memory minReceived = new Output[](1);
+        minReceived[0] = outputMinReceived;
+        FillInstruction[] memory fillInstructions = new FillInstruction[](1);
+        fillInstructions[0] = fillInstruction;
+
+        order = ResolvedCrossChainOrder({
+            user: sponsor,
+            originChainId: 1,
+            openDeadline: 100,
+            fillDeadline: 200,
+            orderId: bytes32(0),
+            maxSpent: maxSpent,
+            minReceived: minReceived,
+            fillInstructions: fillInstructions
+        });
+    }
+
+    function _getMandate() internal view returns (Tribunal.Mandate memory) {
+        return Tribunal.Mandate({
+            recipient: sponsor,
+            expires: 1703116800, // 2023-12-21 00:00:00 UTC
+            token: address(token),
+            minimumAmount: minimumFillAmount,
+            baselinePriorityFee: 100 wei,
+            scalingFactor: 1e18,
+            salt: bytes32(uint256(1))
+        });
+    }
+}
+
+contract ERC7683Tribunal_Fill is MockSetup {
+    function test_revert_InvalidOriginData() public {
+        vm.expectRevert();
+        ERC7683Tribunal.Mandate memory mandate = _getMandate();
+
+        tribunal.fill(order.orderId, abi.encode(claim, mandate, uint8(1)), abi.encode(filler));
+    }
+
+    function test_revert_InvalidFillerData() public {
+        vm.expectRevert();
+        ERC7683Tribunal.Mandate memory mandate = _getMandate();
+
+        tribunal.fill(
+            order.orderId,
+            abi.encode(claim, mandate),
+            abi.encode(filler, makeAddr("AdditionalAddress"))
+        );
+    }
+
+    function test_success() public {
+        token.transfer(sponsor, minimumFillAmount);
+        token.approve(address(tribunal), minimumFillAmount);
+
+        Tribunal.Mandate memory mandate = _getMandate();
+        bytes32 mandateHash = tribunal.deriveMandateHash(mandate);
+        bytes32 claimHash = tribunal.deriveClaimHash(claim, mandateHash);
+
+        vm.expectEmit(true, true, false, true, address(tribunal));
+        emit Tribunal.Fill(sponsor, filler, claimHash, minimumFillAmount, claimAmount);
+        tribunal.fill(order.orderId, order.fillInstructions[0].originData, abi.encode(filler));
+    }
+}

--- a/test/Tribunal.t.sol
+++ b/test/Tribunal.t.sol
@@ -205,7 +205,8 @@ contract TribunalTest is Test {
             allocatorSignature: new bytes(0)
         });
 
-        bytes32 claimHash = tribunal.deriveClaimHash(claim, tribunal.deriveMandateHash(mandate));
+        bytes32 claimHash =
+            tribunal.deriveClaimHash(claim.compact, tribunal.deriveMandateHash(mandate));
         assertFalse(tribunal.filled(claimHash));
 
         vm.expectEmit(true, true, false, true, address(tribunal));
@@ -468,7 +469,8 @@ contract TribunalTest is Test {
         uint256 initialSenderBalance = token.balanceOf(address(this));
 
         // Derive claim hash
-        bytes32 claimHash = tribunal.deriveClaimHash(claim, tribunal.deriveMandateHash(mandate));
+        bytes32 claimHash =
+            tribunal.deriveClaimHash(claim.compact, tribunal.deriveMandateHash(mandate));
 
         vm.expectEmit(true, true, false, true, address(tribunal));
         emit Tribunal.Fill(sponsor, address(this), claimHash, 100e18, 1 ether);
@@ -529,7 +531,7 @@ contract TribunalTest is Test {
         );
 
         // Verify the derived claim hash matches the expected hash
-        assertEq(tribunal.deriveClaimHash(claim, mandateHash), expectedHash);
+        assertEq(tribunal.deriveClaimHash(claim.compact, mandateHash), expectedHash);
     }
 
     /**


### PR DESCRIPTION
Created an ERC7683 compatible version of the Tribunal. 

It is using the `ResolvedCrossChainOrder.fillInstructions[].originData` provided in the [ERC7683 allocator](https://github.com/Uniswap/sc-allocators/pull/6) `open` event