### PR TITLE
ERC7683 target block and duration support

### DIFF
--- a/src/Tribunal.sol
+++ b/src/Tribunal.sol
@@ -328,6 +328,9 @@ contract Tribunal is BlockNumberish {
         uint256 currentFillIncrease;
         uint256 currentClaimDecrease;
         if (targetBlock != 0) {
+            if (targetBlock > _getBlockNumberish()) {
+                revert InvalidTargetBlock(targetBlock, _getBlockNumberish());
+            }
             // Derive the total blocks passed since the target block.
             uint256 blocksPassed = _getBlockNumberish() - targetBlock;
 


### PR DESCRIPTION
Following the [PR for the ERC7683allocator](https://github.com/Uniswap/sc-allocators/pull/7) which is adding support for the latest mandate version (featuring the decayCurve) and allowing open an order including a `targetBlock` and `maximumBlocksAfterTarget`.

Also adds a revert to ensure no underflow is happening if a filler is trying to fill an order with a targetBlock that is still in the future.