### PR TITLE
Allow to cancel claims

### DIFF
--- a/src/ERC7683Tribunal.sol
+++ b/src/ERC7683Tribunal.sol
@@ -19,7 +19,10 @@ contract ERC7683Tribunal is Tribunal, IDestinationSettler {
      * @param originData The encoded Claim and Mandate data.
      * @param fillerData The encoded claimant address.
      */
-    function fill(bytes32, bytes calldata originData, bytes calldata fillerData) external {
+    function fill(bytes32, bytes calldata originData, bytes calldata fillerData)
+        external
+        nonReentrant
+    {
         (
             uint256 chainId,
             Compact calldata compact,

--- a/src/Tribunal.sol
+++ b/src/Tribunal.sol
@@ -164,6 +164,7 @@ contract Tribunal is BlockNumberish {
 
     function cancel(Claim calldata claim, Mandate calldata mandate)
         external
+        payable
         returns (bytes32 claimHash)
     {
         return _cancel(

--- a/test/mocks/ReentrantReceiver.sol
+++ b/test/mocks/ReentrantReceiver.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Tribunal} from "../../src/Tribunal.sol";
+
+contract ReentrantReceiver {
+    error NoProfit(uint256 balanceBefore, uint256 balanceAfter);
+
+    Tribunal private immutable _TRIBUNAL;
+    Tribunal.Claim private _claim;
+    Tribunal.Mandate private _mandate;
+
+    constructor(Tribunal _tribunal) payable {
+        _TRIBUNAL = _tribunal;
+        _claim = Tribunal.Claim({
+            chainId: 1,
+            compact: Tribunal.Compact({
+                arbiter: address(this),
+                sponsor: address(this),
+                nonce: 0,
+                expires: type(uint32).max,
+                id: 0,
+                amount: 0
+            }),
+            sponsorSignature: new bytes(0),
+            allocatorSignature: new bytes(0)
+        });
+        _mandate = Tribunal.Mandate({
+            recipient: address(this),
+            expires: type(uint32).max,
+            token: address(0),
+            minimumAmount: 0,
+            baselinePriorityFee: 0,
+            scalingFactor: 1e18,
+            decayCurve: new uint256[](0),
+            salt: bytes32(uint256(1))
+        });
+    }
+
+    receive() external payable {
+        uint256 quote = _TRIBUNAL.quote(_claim, _mandate, address(this));
+        uint256 balanceBefore = address(this).balance;
+        try _TRIBUNAL.fill{value: quote}(_claim, _mandate, address(this)) {
+            if (address(this).balance < balanceBefore) {
+                revert NoProfit(balanceBefore, address(this).balance);
+            }
+            _claim.compact.nonce++;
+        } catch {}
+    }
+
+    function getClaim() public view returns (Tribunal.Claim memory) {
+        return _claim;
+    }
+
+    function getMandate() public view returns (Tribunal.Mandate memory) {
+        return _mandate;
+    }
+}


### PR DESCRIPTION
Allows the user to cancel claims.
Either exclusively on the target chain by blocking fills, or by invoking a directive with the sponsor as claimant of a zero claim amount.

Added reentrancy protection to ensure a malicious recipient can not reenter the contract during a fill.