### PR TITLE
single chain fill

### DIFF
--- a/src/ERC7683Tribunal.sol
+++ b/src/ERC7683Tribunal.sol
@@ -11,7 +11,7 @@ import {BatchCompact} from "the-compact/src/types/EIP712Types.sol";
 /// @notice A contract that enables the tribunal compatibility with the ERC7683 destination settler interface.
 contract ERC7683Tribunal is Tribunal, IDestinationSettler {
     // ======== Constructor ========
-    constructor() {}
+    constructor(address compact) Tribunal(compact) {}
 
     // ======== External Functions ========
     /**
@@ -32,7 +32,7 @@ contract ERC7683Tribunal is Tribunal, IDestinationSettler {
             Mandate calldata mandate,
             uint256 targetBlock,
             uint256 maximumBlocksAfterTarget,
-            address claimant
+            bytes32 claimant
         ) = _parseCalldata(originData, fillerData);
 
         _fill(
@@ -67,7 +67,7 @@ contract ERC7683Tribunal is Tribunal, IDestinationSettler {
             Mandate calldata mandate,
             ,
             ,
-            address claimant
+            bytes32 claimant
         ) = _parseCalldata(originData, fillerData);
 
         return _quote(chainId, compact, sponsorSignature, allocatorSignature, mandate, claimant);
@@ -97,7 +97,7 @@ contract ERC7683Tribunal is Tribunal, IDestinationSettler {
             Mandate calldata mandate,
             uint256 targetBlock,
             uint256 maximumBlocksAfterTarget,
-            address claimant
+            bytes32 claimant
         )
     {
         /*

--- a/src/Interfaces/ITribunalCallback.sol
+++ b/src/Interfaces/ITribunalCallback.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Lock} from "the-compact/src/types/EIP712Types.sol";
+
+interface ITribunalCallback {
+    /// @notice Callback function to be called by the Tribunal contract to the filler.
+    /// @dev At this point, the filler has received the fillToken with an amount of actualFillAmount.
+    /// @param commitments The commitments that need to be filled.
+    /// @param claimedAmounts The actual amounts required to complete the fill.
+    /// @param fillToken The reward token of the fill.
+    /// @param minimumFillAmount The minimum fill amount that was offered.
+    /// @param actualFillAmount The actual fill amount that is provided.
+    function tribunalCallback(
+        Lock[] calldata commitments,
+        uint256[] calldata claimedAmounts,
+        address fillToken,
+        uint256 minimumFillAmount,
+        uint256 actualFillAmount
+    ) external;
+}


### PR DESCRIPTION
- Implements the ability to fill single chain intent swaps.
- Changes the claimant from address to bytes32. This allows the inclusion of a lockTag with the claimant address, which will symbolize the fillers intent on how to receive the reward tokens.