### PR TITLE
fix: default endScalingFactor to 1e18

### DIFF
--- a/src/lib/PriceCurveLib.sol
+++ b/src/lib/PriceCurveLib.sol
@@ -193,8 +193,10 @@ library PriceCurveLib {
                         (, endScalingFactor) =
                             getComponents(PriceCurveElement.wrap(parameters[i + 1]));
                     } else {
-                        // Last segment ends at zero
-                        endScalingFactor = 0;
+                        // Last segment ends at 1e18
+                        // For exact-in, defaults to decaying fill amount to minFillAmount that the sponsor is willing to accept
+                        // For exact-out, default to increasing claim amounts to maximumClaimAmounts that the sponsor is willing to pay
+                        endScalingFactor = 1e18;
                     }
 
                     if (!scalingFactor.sharesScalingDirection(endScalingFactor)) {

--- a/test/TribunalDeriveAmountsTest.t.sol
+++ b/test/TribunalDeriveAmountsTest.t.sol
@@ -309,8 +309,8 @@ contract TribunalDeriveAmountsTest is Test {
         uint256 targetBlock = vm.getBlockNumber();
 
         uint256[] memory priceCurve = new uint256[](2);
-        priceCurve[0] = (10 << 240) | uint256(8e17); 
-        priceCurve[1] = (10 << 240) | uint256(1e18); 
+        priceCurve[0] = (10 << 240) | uint256(8e17);
+        priceCurve[1] = (10 << 240) | uint256(1e18);
 
         uint256 fillAmount;
         uint256[] memory claimAmounts;


### PR DESCRIPTION
Currently, we end all price curves at a scaling factor of 0. This is not ideal for realistic auction parameterization:
- For exact-in trades, sponsor provides a `minimumFillAmount` they are willing to accept, that is going to be non-zero
- For exact-out trades, sponsor provides `maximumClaimAmounts` they are willing to pay, that are going to be non-zero

In both cases, the sensible default seems to be to converge to neutral, i.e. 1e18:
- For exact-in, fill amount should decay to minimumFillAmount
- For exact-out, claimAmounts should increase to maximumClaimAmounts


**Examples**

To encode an exact-in dutch auction that starts at `1.2 * minFillAmount` and decays to `minFillAmount` over 10 blocks:
- with current implementation:
`priceCurve = [ 10 blocks || 1.2e18, 0 block || 1e18 ] // needs a 0-duration 'terminal node' to end the auction at neutral`
- new implemention:
`priceCurve = [ 10 blocks || 1.2e18 ]` 

To encode an exact-out reverse dutch auction that starts at `0.8 * maxClaimAmounts` and increases to `maxClaimAmounts` over 10 blocks:
- with current implementation:
`priceCurve = [ 10 blocks || 0.8e18, 0 block || 1e18 ] // needs a 0-duration 'terminal node' to end the auction at neutral`
- new implemention:
`priceCurve = [ 10 blocks || 1.2e18 ]` 


Of course, if we actually want the auctions to end at 0, we'll need to add terminal nodes in the new implementation, but that'll rarely be the case in reality.
